### PR TITLE
Add Neos.Fusion.Form (RuntimeForm) support to Ahorn.FriendlyCaptcha

### DIFF
--- a/Classes/FormElements/Captcha.php
+++ b/Classes/FormElements/Captcha.php
@@ -65,37 +65,21 @@ class Captcha extends AbstractFormElement
             return;
         }
 
-
         if (!$response['success']) {
-
-            if ($response['error']['error_code'] === 'auth_required') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1732156724));
-            } elseif($response['error']['error_code'] === 'auth_invalid') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 5786245981));
-            } elseif($response['error']['error_code'] === 'sitekey_invalid') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 7956325875));
-            } elseif($response['error']['error_code'] === 'response_missing') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 8876423767));
-            } elseif($response['error']['error_code'] === 'response_invalid') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1380742852));
-            } elseif($response['error']['error_code'] === 'response_timeout') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1380742853));
-            } elseif($response['error']['error_code'] === 'response_duplicate') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1185587569));
-            } elseif($response['error']['error_code'] === 'bad_request') {
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1380742851));
-            } else{
-              $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
-              $processingRule->getProcessingMessages()->addError(new Error($response['error']['error_code'], 1380742851));
-            }
+            $code = $response['error']['error_code'] ?? 'bad_request';
+            $errorId = match ($code) {
+                'auth_required'      => 1732156724,
+                'auth_invalid'       => 5786245981,
+                'sitekey_invalid'    => 7956325875,
+                'response_missing'   => 8876423767,
+                'response_invalid'   => 1380742852,
+                'response_timeout'   => 1380742853,
+                'response_duplicate' => 1185587569,
+                'bad_request'        => 1380742851,
+                default              => 1380742851,
+            };
+            $processingRule = $this->getRootForm()->getProcessingRule($this->getIdentifier());
+            $processingRule->getProcessingMessages()->addError(new Error($code, $errorId));
         }
     }
 

--- a/Classes/Validation/Validator/FriendlyCaptchaValidator.php
+++ b/Classes/Validation/Validator/FriendlyCaptchaValidator.php
@@ -14,7 +14,7 @@ use Neos\Flow\I18n\Translator;
  * Validator for FriendlyCaptcha
  *
  * @api
- * @Flow\Scope("singleton")
+ * @Flow\Scope("prototype")
  */
 class FriendlyCaptchaValidator extends AbstractValidator
 {

--- a/Classes/Validation/Validator/FriendlyCaptchaValidator.php
+++ b/Classes/Validation/Validator/FriendlyCaptchaValidator.php
@@ -59,7 +59,7 @@ class FriendlyCaptchaValidator extends AbstractValidator
             $this->addError('Missing API key.', 17001);
             return;
         }
-        if (!is_string($value) || $value === '') {
+         if (!is_string($value) || $value === ''||  $value === '.UNACTIVATED' || $value === '.ACTIVATED') {
             $this->addError('Captcha missing.', 17002);
             return;
         }

--- a/Classes/Validation/Validator/FriendlyCaptchaValidator.php
+++ b/Classes/Validation/Validator/FriendlyCaptchaValidator.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Translator;
 
 /**
  * Validator for FriendlyCaptcha
@@ -31,6 +32,9 @@ class FriendlyCaptchaValidator extends AbstractValidator
      * @var LoggerInterface
      */
     protected $logger;
+
+    #[Flow\Inject]
+    protected Translator $translator; 
 
     #[Flow\InjectConfiguration(path: 'apiKey')]
     protected ?string $apiKey = null;
@@ -56,11 +60,11 @@ class FriendlyCaptchaValidator extends AbstractValidator
     {
         
         if (empty($this->apiKey) || $this->apiKey == 'add-your-api-key') {
-            $this->addError('Missing API key.', 17001);
+            $this->addTranslatedErrorById(17001, 'Missing API key.');
             return;
         }
          if (!is_string($value) || $value === ''||  $value === '.UNACTIVATED' || $value === '.ACTIVATED') {
-            $this->addError('Captcha missing.', 17002);
+            $this->addTranslatedErrorById(17002, 'Captcha missing affee.');
             return;
         }
 
@@ -73,7 +77,7 @@ class FriendlyCaptchaValidator extends AbstractValidator
         $response = $raw ? json_decode($raw, true) : [];
 
         if (empty($response)) {
-            $this->addError('Validation server is not responding.', 1735489214);
+            $this->addTranslatedErrorById(1735489214, 'Validation server is not responding.');
         }
 
         if (!$response['success']) {
@@ -89,7 +93,7 @@ class FriendlyCaptchaValidator extends AbstractValidator
                 'bad_request'        => 1380742851,
                 default              => 1380742851,
             };
-            $this->addError($code, $errorId);
+            $this->addTranslatedErrorById($errorId, $code);
         }
     }
 
@@ -126,5 +130,19 @@ class FriendlyCaptchaValidator extends AbstractValidator
                 return null;
             }
         }
+    }
+
+    private function addTranslatedErrorById(int $id, string $fallback = 'Validation error'): void
+    {
+        $msg = $this->translator->translateById(
+            (string)$id,
+            [],               
+            null,             
+            null,             
+            'ValidationErrors',
+            'Ahorn.FriendlyCaptcha' 
+        ) ?? $fallback;
+
+        $this->addError($msg, $id);
     }
 }

--- a/Classes/Validation/Validator/FriendlyCaptchaValidator.php
+++ b/Classes/Validation/Validator/FriendlyCaptchaValidator.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Ahorn\FriendlyCaptcha\Validation\Validator;
+
+use Neos\Flow\Validation\Validator\AbstractValidator;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Log\LoggerInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Validator for FriendlyCaptcha
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class FriendlyCaptchaValidator extends AbstractValidator
+{
+    /**
+     * @var array
+     */
+    protected $supportedOptions = [ 
+        'apiKey'      => [null, 'Override API key', 'string', false],
+        'siteKey'     => [null, 'Override site key', 'string', false],
+        'apiEndpoint' => [null, 'Override endpoint: global|eu|us', 'string', false],
+    ];
+
+    /**
+     * @Flow\Inject
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    #[Flow\InjectConfiguration(path: 'apiKey')]
+    protected ?string $apiKey = null;
+
+    #[Flow\InjectConfiguration(path: 'siteKey')]
+    protected ?string $siteKey = null;
+
+    #[Flow\InjectConfiguration(path: 'apiEndpoint')]
+    protected ?string $apiEndpoint = null;
+
+    protected $acceptsEmptyValues = false;
+
+    protected $supportsEmptyValues = false; 
+
+    protected function initializeObject(): void
+    {
+        $this->apiKey      = $this->options['apiKey']      ?? $this->apiKey;
+        $this->siteKey     = $this->options['siteKey']     ?? $this->siteKey;
+        $this->apiEndpoint = $this->options['apiEndpoint'] ?? $this->apiEndpoint;
+    }
+
+    protected function isValid($value): void
+    {
+        
+        if (empty($this->apiKey) || $this->apiKey == 'add-your-api-key') {
+            $this->addError('Missing API key.', 17001);
+            return;
+        }
+        if (!is_string($value) || $value === '') {
+            $this->addError('Captcha missing.', 17002);
+            return;
+        }
+
+        $raw = $this->verifyCaptchaSolutionV2(
+            'https://' . $this->apiEndpoint . '.frcapi.com/api/v2/captcha/siteverify',
+            $value,
+            $this->apiKey
+        );
+
+        $response = $raw ? json_decode($raw, true) : [];
+
+        if (empty($response)) {
+            $this->addError('Validation server is not responding.', 1735489214);
+        }
+
+        if (!$response['success']) {
+            $code = $response['error']['error_code'] ?? 'unknown_error';
+            $errorId = match ($code) {
+                'auth_required'      => 1732156724,
+                'auth_invalid'       => 5786245981,
+                'sitekey_invalid'    => 7956325875,
+                'response_missing'   => 8876423767,
+                'response_invalid'   => 1380742852,
+                'response_timeout'   => 1380742853,
+                'response_duplicate' => 1185587569,
+                'bad_request'        => 1380742851,
+                default              => 1380742851,
+            };
+            $this->addError($code, $errorId);
+        }
+    }
+
+     private function verifyCaptchaSolutionV2($url, $response, $apiKey)
+    {
+
+        $data = ['response' => $response];
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+            'X-API-Key' => $apiKey,
+        ];
+
+        $client = new Client();
+        $verify = true;
+
+        try {
+            $apiResponse = $client->post($url, [
+                'headers' => $headers,
+                'json' => $data,
+                'timeout' => 5,
+                'verify' => $verify,
+            ]);
+
+            $body = $apiResponse->getBody()->getContents();
+
+            return $body;
+
+        } catch (RequestException $e) {
+            if ($e->hasResponse()) {
+                $errorBody = $e->getResponse()->getBody()->getContents();
+                return $errorBody;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,3 @@
 # Configuration/Objects.yaml
 Ahorn\FriendlyCaptcha\Validation\Validator\FriendlyCaptchaValidator:
-  scope: singleton
+  scope: prototype

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,3 @@
+# Configuration/Objects.yaml
+Ahorn\FriendlyCaptcha\Validation\Validator\FriendlyCaptchaValidator:
+  scope: singleton

--- a/README.md
+++ b/README.md
@@ -130,7 +130,11 @@ set in the schema
 
 ```yaml
       schema {
-          captcha = ${Form.Schema.string().validator('Ahorn.FriendlyCaptcha:FriendlyCaptcha', {apiKey: abc123, siteKey: abc123, apiEndpoint: eu}) }
+          captcha = ${Form.Schema.string().validator('Ahorn.FriendlyCaptcha:FriendlyCaptcha',{
+            siteKey: 'override-siteKey',
+            apiKey: 'override-apiKey',
+            apiEndpoint: 'global'
+          })}
       }
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,3 +102,35 @@ If you see an error code in the frontend it is most likely to be an configuratio
 * 5786245981: The apiKey is invalid.
 * 7956325875: Sitekey is invalid.
 * 1380742851: An unknown error has occurred. Check the settings.
+
+---
+## Neos Fusion Form
+
+```yaml
+ process {
+
+      content = afx`
+          <Neos.Fusion.Form:FieldContainer field.name="captcha">
+            <Ahorn.FriendlyCaptcha:Fusion.Captcha />
+          </Neos.Fusion.Form:FieldContainer>
+    `
+
+      schema {
+          captcha = ${Form.Schema.string().validator('Ahorn.FriendlyCaptcha:FriendlyCaptcha')}
+      }
+  }
+```
+or use options to set API Key
+
+        'apiKey'      => [null, 'Override API key', 'string', false],
+        'siteKey'     => [null, 'Override site key', 'string', false],
+        'apiEndpoint' => [null, 'Override endpoint: global|eu|us', 'string', false],
+
+set in the schema
+
+```yaml
+      schema {
+          captcha = ${Form.Schema.string().validator('Ahorn.FriendlyCaptcha:FriendlyCaptcha', {apiKey: abc123, siteKey: abc123, apiEndpoint: eu}) }
+      }
+```
+

--- a/Resources/Private/Fusion/Documents/Page.fusion
+++ b/Resources/Private/Fusion/Documents/Page.fusion
@@ -6,7 +6,7 @@ prototype(Neos.Neos:Page) {
         tagName = 'script'
         attributes {
             type = 'module'
-            src = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.9/site.min.js'
+            src = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.32/site.min.js'
             async = true
             defer = true
         }
@@ -18,7 +18,7 @@ prototype(Neos.Neos:Page) {
         tagName = 'script'
         attributes {
             nomodule = true
-            src = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.9/site.min.js'
+            src = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.32/site.min.js'
             async = true
             defer = true
         }

--- a/Resources/Private/Fusion/FusionForm.fusion
+++ b/Resources/Private/Fusion/FusionForm.fusion
@@ -1,0 +1,23 @@
+prototype(Ahorn.FriendlyCaptcha:Fusion.Captcha) < prototype(Neos.Fusion.Form:Component.Field) {
+  siteKey = ${Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') ? Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') : null}
+  startVerification = ${Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') ? Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') : 'auto'}
+  language = ${String.crop(documentNode.context.dimensions[languageDimension][0], 2)}
+  language.@if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + languageDimension) != null}
+  apiEndpoint = ${Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') ? Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') : 'global'}
+  theme = ${Configuration.setting('Ahorn.FriendlyCaptcha.theme') ? Configuration.setting('Ahorn.FriendlyCaptcha.theme') : 'auto'}
+
+  renderer = afx`
+    <div class="form-frc-captcha">
+      <div class="frc-captcha"
+           data-sitekey={props.siteKey}
+           data-theme={props.theme}
+           data-start={props.startVerification}
+           data-lang={props.language}
+           data-form-field-name={field.getName()}>
+           <input type="hidden" 
+           name={field.getName()} 
+           value=""/>
+      </div>
+    </div>
+  `
+}

--- a/Resources/Private/Fusion/FusionForm.fusion
+++ b/Resources/Private/Fusion/FusionForm.fusion
@@ -1,8 +1,7 @@
 prototype(Ahorn.FriendlyCaptcha:Fusion.Captcha) < prototype(Neos.Fusion.Form:Component.Field) {
   siteKey = ${Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') ? Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') : null}
   startVerification = ${Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') ? Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') : 'auto'}
-  language = ${String.crop(documentNode.context.dimensions[languageDimension][0], 2)}
-  language.@if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + languageDimension) != null}
+  currentLanguage = ${node.context.targetDimensions.language}
   apiEndpoint = ${Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') ? Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') : 'global'}
   theme = ${Configuration.setting('Ahorn.FriendlyCaptcha.theme') ? Configuration.setting('Ahorn.FriendlyCaptcha.theme') : 'auto'}
 
@@ -12,7 +11,7 @@ prototype(Ahorn.FriendlyCaptcha:Fusion.Captcha) < prototype(Neos.Fusion.Form:Com
            data-sitekey={props.siteKey}
            data-theme={props.theme}
            data-start={props.startVerification}
-           data-lang={props.language}
+           data-lang={props.currentLanguage}
            data-form-field-name={field.getName()}>
            <input type="hidden" 
            name={field.getName()} 

--- a/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -3,7 +3,7 @@
   <file original="" product-name="Ahorn.FriendlyCaptcha" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <trans-unit id="17002" xml:space="preserve" approved="yes">
-        <source>Captcha missing.</source>
+        <source>Please confirm that you are not a robot.</source>
         <target>Bitte bestätigen Sie, dass Sie kein Roboter sind.</target>
       </trans-unit>
       <trans-unit id="17001" xml:space="preserve" approved="yes">

--- a/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -2,6 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Ahorn.FriendlyCaptcha" source-language="en" datatype="plaintext" target-language="de">
     <body>
+      <trans-unit id="17002" xml:space="preserve" approved="yes">
+        <source>Captcha missing.</source>
+        <target>Bitte bestätigen Sie, dass Sie kein Roboter sind.</target>
+      </trans-unit>
+      <trans-unit id="17001" xml:space="preserve" approved="yes">
+        <source>Missing API key.</source>
+        <target>API-Schlüssel fehlt.</target>
+      </trans-unit>
       <trans-unit id="17942348245" xml:space="preserve" approved="yes">
         <source>Error Code: 17942348245. Please try again later.</source>
         <target>Fehlercode: 17942348245. Bitte versuchen Sie es zu einem späteren Zeitpunkt nochmals.</target>

--- a/Resources/Private/Translations/en/ValidationErrors.xlf
+++ b/Resources/Private/Translations/en/ValidationErrors.xlf
@@ -2,6 +2,12 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="" product-name="Ahorn.FriendlyCaptcha" source-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="17002" xml:space="preserve" approved="yes">
+        <source>Captcha missing.</source>
+      </trans-unit>
+      <trans-unit id="17001" xml:space="preserve" approved="yes">
+        <source>Missing API key.</source>
+      </trans-unit>
       <trans-unit id="17942348245" xml:space="preserve" approved="yes">
         <source>Error Code: 17942348245. Please try again later.</source>
       </trans-unit>

--- a/Resources/Private/Translations/en/ValidationErrors.xlf
+++ b/Resources/Private/Translations/en/ValidationErrors.xlf
@@ -3,7 +3,7 @@
   <file original="" product-name="Ahorn.FriendlyCaptcha" source-language="en" datatype="plaintext">
     <body>
       <trans-unit id="17002" xml:space="preserve" approved="yes">
-        <source>Captcha missing.</source>
+        <source>Please confirm that you are not a robot.</source>
       </trans-unit>
       <trans-unit id="17001" xml:space="preserve" approved="yes">
         <source>Missing API key.</source>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
     "description": "Form Element to integrate Friendly Captcha into the Flow Form Framework",
     "require": {
         "neos/form": "^5.0",
-        "guzzlehttp/psr7": "^1.4 || ^2.0"
+        "neos/fusion-form": "^3.0",
+        "guzzlehttp/psr7": "^1.4 || ^2.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary 

This PR adds full support for Neos.Fusion.Form:Runtime.RuntimeForm (AFX) to the package.
It introduces a Fusion component, a Fusion-ready validator, i18n messages, and a robust SDK integration so FriendlyCaptcha can be used natively in Fusion forms (without the old Fluid FormEngine).

## Motivation 

Projects using Neos.Fusion.Form previously hit:

missing parentRenderable context,

wrong field mapping/namespacing,

empty captcha values at submit time (timing issues),

validator not firing / missing translations.

This PR addresses all of the above and makes Fusion usage first-class.