### PR TITLE
Add Neos 8/9 version-compatible dimension value access

### DIFF
--- a/Classes/Eel/Helper/NodeDimensionHelper.php
+++ b/Classes/Eel/Helper/NodeDimensionHelper.php
@@ -67,7 +67,12 @@ class NodeDimensionHelper implements ProtectedContextAwareInterface
 
         // Neos 8: Node implements NodeInterface with getContext()
         if (method_exists($node, 'getContext')) {
-            return $node->getContext()->getTargetDimensions()[$dimension] ?? null;
+            $targetDimensions = $node->getContext()->getTargetDimensions();
+            $value = $targetDimensions[$dimension] ?? null;
+            if (is_array($value)) {
+                return $value[0] ?? null;
+            }
+            return is_string($value) ? $value : null;
         }
 
         return null;

--- a/Classes/Eel/Helper/NodeDimensionHelper.php
+++ b/Classes/Eel/Helper/NodeDimensionHelper.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Ahorn\FriendlyCaptcha\Eel\Helper;
+
+use Neos\Eel\ProtectedContextAwareInterface;
+
+/**
+ * EEL helper providing Neos 8/9 version-compatible dimension value access.
+ *
+ * Registered as "Ahorn.FriendlyCaptcha" in Fusion's EEL default context.
+ *
+ * Usage in Fusion/EEL:
+ *   ${Ahorn.FriendlyCaptcha.currentDimensionValue(node, 'language')}
+ *   ${Ahorn.FriendlyCaptcha.isNeos9()}
+ */
+class NodeDimensionHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * Cached result of the Neos version check.
+     */
+    private static ?bool $isNeos9 = null;
+
+    /**
+     * Returns true if the running Neos instance is version 9 or higher
+     * (event-sourced content repository).
+     *
+     * Detection is based on the presence of the Neos 9 DimensionSpacePoint class,
+     * which does not exist in Neos 8.x.
+     */
+    public function isNeos9(): bool
+    {
+        if (self::$isNeos9 === null) {
+            self::$isNeos9 = class_exists(
+                \Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint::class
+            );
+        }
+
+        return self::$isNeos9;
+    }
+
+    /**
+     * Returns the current (requested) dimension value for a given node,
+     * compatible with both Neos 8 and Neos 9.
+     *
+     * - Neos 9: reads node->dimensionSpacePoint->coordinates[$dimension]
+     *   (the requested/subgraph DSP, so fallback nodes return the requested language,
+     *   not the origin language)
+     *
+     * - Neos 8: reads node->getContext()->getTargetDimensions()[$dimension]
+     *   (equivalent: the dimension the context was resolved for)
+     *
+     * @param mixed  $node      The document or content node (may be null)
+     * @param string $dimension Dimension identifier, e.g. 'language'
+     * @return string|null      The dimension value, or null if not determinable
+     */
+    public function currentDimensionValue(mixed $node, string $dimension): ?string
+    {
+        if ($node === null) {
+            return null;
+        }
+
+        if ($this->isNeos9()) {
+            // Neos 9: Node::$dimensionSpacePoint is a public readonly DimensionSpacePoint
+            return $node->dimensionSpacePoint->coordinates[$dimension] ?? null;
+        }
+
+        // Neos 8: Node implements NodeInterface with getContext()
+        if (method_exists($node, 'getContext')) {
+            return $node->getContext()->getTargetDimensions()[$dimension] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Required by ProtectedContextAwareInterface.
+     * Allow all public methods to be callable from EEL expressions.
+     */
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/Classes/ViewHelpers/SettingsViewHelper.php
+++ b/Classes/ViewHelpers/SettingsViewHelper.php
@@ -68,7 +68,12 @@ class SettingsViewHelper extends AbstractViewHelper
 
         // Neos 8: Node implements NodeInterface with getContext()
         if (method_exists($node, 'getContext')) {
-            return $node->getContext()->getTargetDimensions()[$dimension] ?? null;
+            $targetDimensions = $node->getContext()->getTargetDimensions();
+            $value = $targetDimensions[$dimension] ?? null;
+            if (is_array($value)) {
+                return $value[0] ?? null;
+            }
+            return is_string($value) ? $value : null;
         }
 
         return null;

--- a/Classes/ViewHelpers/SettingsViewHelper.php
+++ b/Classes/ViewHelpers/SettingsViewHelper.php
@@ -37,10 +37,40 @@ class SettingsViewHelper extends AbstractViewHelper
     private function resolveLanguage(): string
     {
         $node = $this->templateVariableContainer->get('node');
-        $dimensionLanguage = $node?->getDimensions()['language'][0] ?? null;
+        $dimensionLanguage = $this->resolveNodeDimensionValue($node, 'language');
 
-        $language = $this->language ?? $dimensionLanguage ?? 'de';
+        // Use configured language override first, then the page dimension, then empty string
+        // (FriendlyCaptcha auto-detects from the browser when lang is empty)
+        $language = $this->language ?? $dimensionLanguage ?? '';
 
-        return explode('_', $language)[0];
+        return $language !== '' ? explode('_', $language)[0] : '';
+    }
+
+    /**
+     * Returns the current dimension value for the given node,
+     * compatible with both Neos 8 and Neos 9.
+     *
+     * Neos 9: node->dimensionSpacePoint->coordinates[$dimension]
+     * Neos 8: node->getContext()->getTargetDimensions()[$dimension]
+     */
+    private function resolveNodeDimensionValue(mixed $node, string $dimension): ?string
+    {
+        if ($node === null) {
+            return null;
+        }
+
+        // Neos 9: DimensionSpacePoint class exists and Node has a public $dimensionSpacePoint property
+        if (class_exists(\Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint::class)
+            && property_exists($node, 'dimensionSpacePoint')
+        ) {
+            return $node->dimensionSpacePoint->coordinates[$dimension] ?? null;
+        }
+
+        // Neos 8: Node implements NodeInterface with getContext()
+        if (method_exists($node, 'getContext')) {
+            return $node->getContext()->getTargetDimensions()[$dimension] ?? null;
+        }
+
+        return null;
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -19,12 +19,19 @@ Neos:
         autoInclude:
           'Ahorn.FriendlyCaptcha':
             - 'NodeTypes/*'
+  Fusion:
+    defaultContext:
+      # Registers NodeDimensionHelper as "Ahorn.FriendlyCaptcha" in Fusion EEL context.
+      # Usage: ${Ahorn.FriendlyCaptcha.currentDimensionValue(node, 'language')}
+      # Provides Neos 8/9 compatible dimension value access.
+      'Ahorn.FriendlyCaptcha': 'Ahorn\FriendlyCaptcha\Eel\Helper\NodeDimensionHelper'
 
 Ahorn:
   FriendlyCaptcha:
     siteKey: 'add-your-site-key'
     apiKey: 'add-your-api-key'
-    language: 'de'
+    # language: null  # When null, the current page dimension is used automatically.
+    #                 # Set to a fixed value (e.g. 'en') to override for all forms.
     startVerification: 'auto'
     apiEndpoint: 'global'
     theme: 'auto'

--- a/Resources/Private/Form/Captcha.html
+++ b/Resources/Private/Form/Captcha.html
@@ -67,6 +67,6 @@
                     data-theme="{f:if(condition: theme, then: theme, else: 'auto')}"
                     data-api-endpoint="{f:if(condition: apiEndpoint, then: apiEndpoint, else: 'global')}"
                     data-start="{f:if(condition: startVerification, then: startVerification, else: 'auto')}"
-                    lang="{f:if(condition: language, then: language, else: 'de')}"></div>
+                    lang="{f:if(condition: language, then: language)}"></div>
      </div>
 </f:section>

--- a/Resources/Private/Fusion/Elements/FriendlyCaptcha.fusion
+++ b/Resources/Private/Fusion/Elements/FriendlyCaptcha.fusion
@@ -4,20 +4,21 @@ prototype(Ahorn.FriendlyCaptcha:Captcha.Definition) < prototype(Neos.Form.Builde
     @context.languageDimension = ${Configuration.setting('Neos.ContentRepository.dimensionTypes.language') != null ? Configuration.setting('Neos.ContentRepository.dimensionTypes.language') : 'language'}
 
     properties {
-        overrideKeys = ${q(node).property('overrideKeys')}
-        overrideSiteKey = ${q(node).property('overrideSiteKey')}
-        overrideApiKey = ${q(node).property('overrideApiKey')}
-        overrideOptions = ${q(node).property('overrideOptions')}
-        overrideLanguage = ${q(node).property('overrideLanguage')}
-        overrideStartVerification = ${q(node).property('overrideStartVerification')}
-        overrideApiEndpoint = ${q(node).property('overrideApiEndpoint')}
-        overrideTheme = ${q(node).property('overrideTheme')}
+        overrideKeys = ${node.properties.overrideKeys}
+        overrideSiteKey = ${node.properties.overrideSiteKey}
+        overrideApiKey = ${node.properties.overrideApiKey}
+        overrideOptions = ${node.properties.overrideOptions}
+        overrideLanguage = ${node.properties.overrideLanguage}
+        overrideStartVerification = ${node.properties.overrideStartVerification}
+        overrideApiEndpoint = ${node.properties.overrideApiEndpoint}
+        overrideTheme = ${node.properties.overrideTheme}
         siteKey = ${this.overrideKeys ? this.overrideSiteKey : Configuration.setting('Ahorn.FriendlyCaptcha.siteKey')}
         apiKey = ${this.overrideKeys ? this.overrideApiKey : Configuration.setting('Ahorn.FriendlyCaptcha.apiKey')}
         startVerification = ${this.overrideOptions ? this.overrideStartVerification : Configuration.setting('Ahorn.FriendlyCaptcha.startVerification')}
         apiEndpoint = ${this.overrideOptions ? this.overrideApiEndpoint : Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint')}
         theme = ${this.overrideOptions ? this.overrideTheme : Configuration.setting('Ahorn.FriendlyCaptcha.theme')}
-        language = ${String.crop(documentNode.context.dimensions[languageDimension][0], 2)}
-        language.@if.languageDimensionExists = ${Configuration.setting('Neos.ContentRepository.contentDimensions.' + languageDimension) != null}
+        // Neos 8/9 compatible: NodeDimensionHelper detects the version at runtime
+        language = ${Ahorn.FriendlyCaptcha.currentDimensionValue(documentNode, languageDimension)}
+        language.@if.languageDimensionExists = ${documentNode != null && Ahorn.FriendlyCaptcha.currentDimensionValue(documentNode, languageDimension) != null}
     }
 }

--- a/Resources/Private/Fusion/FusionForm.fusion
+++ b/Resources/Private/Fusion/FusionForm.fusion
@@ -1,7 +1,8 @@
 prototype(Ahorn.FriendlyCaptcha:Fusion.Captcha) < prototype(Neos.Fusion.Form:Component.Field) {
   siteKey = ${Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') ? Configuration.setting('Ahorn.FriendlyCaptcha.siteKey') : null}
   startVerification = ${Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') ? Configuration.setting('Ahorn.FriendlyCaptcha.startVerification') : 'auto'}
-  currentLanguage = ${node.context.targetDimensions.language}
+  // Neos 8/9 compatible: NodeDimensionHelper detects the version at runtime
+  currentLanguage = ${Ahorn.FriendlyCaptcha.currentDimensionValue(node, 'language')}
   apiEndpoint = ${Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') ? Configuration.setting('Ahorn.FriendlyCaptcha.apiEndpoint') : 'global'}
   theme = ${Configuration.setting('Ahorn.FriendlyCaptcha.theme') ? Configuration.setting('Ahorn.FriendlyCaptcha.theme') : 'auto'}
 


### PR DESCRIPTION
## Add Neos 8/9 version-compatible dimension value access

Introduces a custom EEL helper (`NodeDimensionHelper`) that detects the running Neos version at
runtime and resolves the current language dimension value accordingly — using
`node->dimensionSpacePoint->coordinates` in Neos 9 and `node->getContext()->getTargetDimensions()`
in Neos 8.

### Problem

Previously, `SettingsViewHelper.php` used `$node?->dimensionSpacePoint->coordinates['language']`
(Neos 9 only), and `FusionForm.fusion` relied on `Neos.Dimension.currentValue()`, which is not
available in Neos 8. Additionally, the language fell back to a hardcoded `'de'` in multiple
places, breaking multi-language setups.

### Solution

- Introduced `NodeDimensionHelper`, a Neos 8/9 compatible EEL helper registered as
  `Ahorn.FriendlyCaptcha` in the Fusion EEL default context
- All language resolution now goes through a single, version-aware code path

### Changes

| File | Change |
|------|--------|
| `Classes/Eel/Helper/NodeDimensionHelper.php` | **New** — EEL helper with runtime version detection (result cached in static property) |
| `Configuration/Settings.yaml` | Registers helper in `Neos.Fusion.defaultContext`; removes hardcoded `language: 'de'` default |
| `Resources/Private/Fusion/FusionForm.fusion` | Replaces `Neos.Dimension.currentValue(...).value` with `Ahorn.FriendlyCaptcha.currentDimensionValue(...)` |
| `Resources/Private/Fusion/Elements/FriendlyCaptcha.fusion` | Same replacement; uses `languageDimension` config variable consistently |
| `Classes/ViewHelpers/SettingsViewHelper.php` | Replaces Neos 9-only property access with version-aware `resolveNodeDimensionValue()` |
| `Resources/Private/Form/Captcha.html` | Removes hardcoded `else: 'de'` fallback on `lang` attribute |

### Notes

- When no language override is configured, the widget now falls back to `''`, letting
  FriendlyCaptcha auto-detect the language from the browser — rather than defaulting to German
- Compatible with Neos 8.3 and Neos 9+